### PR TITLE
profiler add rowCount and variableOrder

### DIFF
--- a/server/opendp_apps/profiler/profile_formatter.py
+++ b/server/opendp_apps/profiler/profile_formatter.py
@@ -29,13 +29,20 @@ class ProfileFormatter:
         #
         if 'dataset' in profile_data:
             features_to_keep = [ "variableCount", "variableOrder"]
+            features_to_nullify = []
             if save_row_count is True:
                 features_to_keep.append('rowCount')
+            else:
+                features_to_nullify.append('rowCount')
+
             features_to_del = []
 
             for key in profile_data['dataset']:
                 if not key in features_to_keep:
-                    features_to_del.append(key)
+                    if key in features_to_nullify:
+                        profile_data['dataset'][key] = None
+                    else:
+                        features_to_del.append(key)
 
             for del_key in features_to_del:
                 del profile_data['dataset'][del_key]

--- a/server/opendp_apps/profiler/profile_handler.py
+++ b/server/opendp_apps/profiler/profile_handler.py
@@ -52,7 +52,7 @@ class ProfileHandler(BasicErrCheck):
         # -------------------------------------
         # Indices of columns to profile. Default is the 1st 20 indices
         self.max_num_features = kwargs.get('max_num_features', settings.PROFILER_COLUMN_LIMIT)
-        self.save_row_count = kwargs.get('save_row_count', True)    # set to False depending on epsilon question
+        self.save_row_count = kwargs.get(pstatic.KEY_SAVE_ROW_COUNT, True)    # set to False depending on epsilon question
 
         # If a DataSetInfo object is specified, the profile will be saved to the object
         self.dataset_info_object_id = kwargs.get(pstatic.KEY_DATASET_OBJECT_ID)
@@ -328,7 +328,7 @@ class ProfileHandler(BasicErrCheck):
             return
 
         self.data_profile = prunner.get_final_dict()
-        print('variable_order', self.variable_order)
+        #print('variable_order', self.variable_order)
         self.data_profile['dataset']['variableOrder'] = self.variable_order
 
         self.prune_profile()

--- a/server/opendp_apps/profiler/static_vals.py
+++ b/server/opendp_apps/profiler/static_vals.py
@@ -1,6 +1,7 @@
 
 # keyword param for the ProfileHandler
 KEY_DATASET_OBJECT_ID = 'dataset_object_id'
+KEY_SAVE_ROW_COUNT = 'save_row_count'
 KEY_DATASET_IS_DJANGO_FILEFIELD = 'dataset_is_django_filefield'
 KEY_DATASET_IS_FILEPATH = 'dataset_is_filepath'
 

--- a/server/opendp_apps/profiler/tasks.py
+++ b/server/opendp_apps/profiler/tasks.py
@@ -6,11 +6,12 @@ from opendp_apps.profiler import static_vals as pstatic
 
 
 @celery_app.task(ignore_result=True)
-def run_profile_by_filepath(filepath, dataset_object_id=None):
+def run_profile_by_filepath(filepath, dataset_object_id=None, **kwargs):
     """Run the profiler using a valid filepath"""
     params = {pstatic.KEY_DATASET_IS_FILEPATH: True}
 
     params[pstatic.KEY_DATASET_OBJECT_ID] = dataset_object_id
+    params[pstatic.KEY_SAVE_ROW_COUNT] = kwargs.get(pstatic.KEY_SAVE_ROW_COUNT, True)
 
     ph = ProfileHandler(dataset_pointer=filepath, **params)
 
@@ -21,7 +22,9 @@ def run_profile_by_filepath(filepath, dataset_object_id=None):
 def run_profile_by_filefield(dataset_info_object_id, **kwargs):
     """Run the profiler using a valid filepath"""
     params = {pstatic.KEY_DATASET_IS_DJANGO_FILEFIELD: True,
-              pstatic.KEY_DATASET_OBJECT_ID: dataset_info_object_id}
+              pstatic.KEY_DATASET_OBJECT_ID: dataset_info_object_id,
+              pstatic.KEY_SAVE_ROW_COUNT: kwargs.get(pstatic.KEY_SAVE_ROW_COUNT, True)
+              }
 
     try:
         ds_info = DataSetInfo.objects.get(object_id=dataset_info_object_id)

--- a/server/opendp_apps/profiler/testing/test_profiler.py
+++ b/server/opendp_apps/profiler/testing/test_profiler.py
@@ -4,6 +4,7 @@ CURRENT_DIR = dirname(abspath(__file__))
 TEST_DATA_DIR = join(dirname(dirname(dirname(CURRENT_DIR))), 'test_data')
 
 import json
+from unittest import skip
 
 from django.test import TestCase #Client, tag
 from django.conf import settings
@@ -65,11 +66,18 @@ class ProfilerTest(TestCase):
 
         pvars = profiler.profile_variables
         self.assertTrue('variables' in info)
-        self.assertTrue(len(pvars['variables']) <= len(settings.PROFILER_DEFAULT_COLUMN_INDICES))
+        self.assertTrue(len(pvars['variables']) <= settings.PROFILER_COLUMN_LIMIT)
         self.assertEqual(len(pvars['variables']), info['dataset']['variableCount'])
 
+        self.assertEqual(info['dataset']['variableCount'],
+                         len(info['dataset']['variableOrder']))
 
+        # make the sure the "dataset.variableOrder" column names are in the "variables" dict
+        #
+        for idx, colname in info['dataset']['variableOrder']:
+            self.assertTrue(colname in info['variables'])
 
+    #@skip
     def test_005_profile_good_files(self):
         """(05) Profile several good files"""
         msgt(self.test_005_profile_good_files.__doc__)
@@ -127,7 +135,7 @@ class ProfilerTest(TestCase):
 
         print('-- Profiler reads only first 20 features')
         self.assertTrue('variables' in info)
-        self.assertEqual(len(info['variables'].keys()), len(settings.PROFILER_DEFAULT_COLUMN_INDICES))
+        self.assertEqual(len(info['variables'].keys()), settings.PROFILER_COLUMN_LIMIT)
 
         print('-- Profiler output is the same as the output saved to the DataSetInfo object')
         profile_json_str2 = json.dumps(info, cls=DjangoJSONEncoder, indent=4)
@@ -135,8 +143,18 @@ class ProfilerTest(TestCase):
         print(profile_json_str2)
 
         self.assertEqual(dsi.profile_variables['dataset']['variableCount'],
-                         len(settings.PROFILER_DEFAULT_COLUMN_INDICES))
+                         settings.PROFILER_COLUMN_LIMIT)
 
+        self.assertEqual(dsi.profile_variables['dataset']['variableCount'],
+                         len(dsi.profile_variables['dataset']['variableOrder']))
+
+        # make the sure the "dataset.variableOrder" column names are in the "variables" dict
+        #
+        for idx, colname in dsi.profile_variables['dataset']['variableOrder']:
+            self.assertTrue(colname in dsi.profile_variables['variables'])
+
+
+    #@skip
     def test_020_bad_files(self):
         """(20) Test bad file type"""
         msgt(self.test_020_bad_files.__doc__)
@@ -170,6 +188,7 @@ class ProfilerTest(TestCase):
         self.assertTrue(profiler.get_err_msg().find('EmptyDataError') > -1)
 
 
+    #@skip
     def test_30_filefield_empty(self):
         """(30) Test with empty file field"""
         msgt(self.test_30_filefield_empty.__doc__)
@@ -194,6 +213,7 @@ class ProfilerTest(TestCase):
                          DepositorSetupInfo.DepositorSteps.STEP_9300_PROFILING_FAILED)
 
 
+    #@skip
     def test_40_filefield_correct(self):
         """(40) Test using file file with legit file"""
         msgt(self.test_40_filefield_correct.__doc__)
@@ -230,14 +250,22 @@ class ProfilerTest(TestCase):
 
         print('-- Profiler reads only first 20 features')
         self.assertTrue('variables' in info)
-        self.assertEqual(len(info['variables'].keys()), len(settings.PROFILER_DEFAULT_COLUMN_INDICES))
+        self.assertEqual(len(info['variables'].keys()), settings.PROFILER_COLUMN_LIMIT)
 
         self.assertEqual(dsi2.depositor_setup_info.user_step, \
                          DepositorSetupInfo.DepositorSteps.STEP_0400_PROFILING_COMPLETE)
 
         #print('dsi2.profile_variables', dsi2.profile_variables)
         self.assertEqual(len(dsi2.profile_variables['variables'].keys()),
-                         len(settings.PROFILER_DEFAULT_COLUMN_INDICES))
+                         settings.PROFILER_COLUMN_LIMIT)
 
         self.assertEqual(dsi2.profile_variables['dataset']['variableCount'],
-                         len(settings.PROFILER_DEFAULT_COLUMN_INDICES))
+                         settings.PROFILER_COLUMN_LIMIT)
+
+        self.assertEqual(dsi2.profile_variables['dataset']['variableCount'],
+                         len(dsi2.profile_variables['dataset']['variableOrder']))
+
+        # make the sure the "dataset.variableOrder" column names are in the "variables" dict
+        #
+        for idx, colname in dsi2.profile_variables['dataset']['variableOrder']:
+            self.assertTrue(colname in dsi2.profile_variables['variables'])

--- a/server/opendp_project/settings/base.py
+++ b/server/opendp_project/settings/base.py
@@ -293,11 +293,8 @@ ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL = '/log-in/'
 # Profiler - Dataset reading
 #   - default parameters
 # ---------------------------
-PROFILER_VARIABLE_INDICES = '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]'
-# ', '.join([str(x) for x in range(0,20)])
-PROFILER_DEFAULT_COLUMN_INDICES = json.loads(os.environ.get('PROFILER_DEFAULT_COLUMN_INDICES',
-                                                            PROFILER_VARIABLE_INDICES))
-
+PROFILER_COLUMN_LIMIT = int(os.environ.get('PROFILER_COLUMN_LIMIT', 20))
+assert PROFILER_COLUMN_LIMIT >= 1, 'PROFILER_COLUMN_LIMIT must be at least 1'
 
 # -----------------------------------------------
 # Websocket prefix.


### PR DESCRIPTION
For the profiler output, add rowCount and variableOrder.

Note: if specified previous to profiling; `dataset.rowCount` will equal `None` (or null in js)

Example:
```json
{
   "self":{
      "created_at":"2021-09-10 19:59:01",
      "description":"TwoRavens metadata generated by https://github.com/TwoRavens/raven-metadata-service"
   },
   "$schema":"https://github.com/TwoRavens/raven-metadata-service/schema/jsonschema/1-2-0.json#",
   "dataset":{
      "rowCount":6610,
      "variableCount":20,
      "variableOrder":[
         [
            0,
            "ccode"
         ],
         [
            1,
            "country"
         ],
         [
            2,
            "cname"
         ],
         [
            3,
            "cmark"
         ],
         [
            4,
            "year"
         ]
      ]
   }
}
```