### PR TITLE
run computation endpoint (direct run)

### DIFF
--- a/server/opendp_apps/analysis/models.py
+++ b/server/opendp_apps/analysis/models.py
@@ -197,6 +197,8 @@ class ReleaseInfo(TimestampedModelWithUUID):
                                      validators=[validate_not_negative])
     dp_release = models.JSONField()
 
+
+
     #pdf_release
 
     class Meta:

--- a/server/opendp_apps/analysis/release_info_formatter.py
+++ b/server/opendp_apps/analysis/release_info_formatter.py
@@ -1,0 +1,90 @@
+"""
+Given a ValidateReleaseUtil object that has computed stat,
+build the release dict!
+"""
+from datetime import datetime as dt
+from opendp_apps.model_helpers.basic_err_check import BasicErrCheck
+
+
+class ReleaseInfoFormatter(BasicErrCheck):
+
+    def __init__(self, release_util):
+        """Init with a ValidateReleaseUtil object"""
+        self.release_util = release_util
+        self.release_dict = {}
+        self.check_it()
+
+    def check_it(self):
+        """Make sure the computation has been finished"""
+        if self.release_util.has_error():
+            self.add_err_msg(self.release_util.get_err_msg())
+            return
+
+        stat_list = self.release_util.get_release_stats()
+        if not stat_list:
+            self.add_err_msg('.get_release_stats() failed!')
+            return
+
+    def get_readable_datetime(self, dt_obj: dt):
+        """
+        Format a datetime object
+        https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+        """
+        tz_str = dt_obj.strftime("%Z")
+        if tz_str:
+            tz_str= f' {tz_str}'
+
+        readable_str = dt_obj.strftime("%B") + ' ' \
+                       + dt_obj.strftime("%d") + ', ' \
+                       + dt_obj.strftime("%Y") \
+                       + ' at ' + dt_obj.strftime("%H:%M:%S:%f") \
+                       + tz_str
+        return readable_str
+
+
+    def get_release_data(self):
+        """Return the release!"""
+        current_dt = dt.now()
+
+        self.release_dict = \
+        {
+            "name": str(self.release_util.analysis_plan),
+            "release_url": '(not available, should be url within DP Creator)',
+            "created": {
+                "iso": current_dt.isoformat(),
+                "human_readable": self.get_readable_datetime(current_dt)
+            },
+            "application": "DP Creator",
+            "application_url": "https://github.com/opendp/dpcreator",
+            "differentially_private_library": {
+                "name": "OpenDP",
+                "url": "https://github.com/opendp/opendp",
+                "version": self.release_util.opendp_version,
+            },
+            "dataset": {
+                "dataverse": {
+                    "release_deposit_info": {
+                        "deposited": True,
+                        "dv_urls_to_release": {
+                            "release_json": "http://dataverse.edu/some.json",
+                            "release_pdf": "http://dataverse.edu/some.pdf"
+                        }
+                    },
+                    "installation": {
+                        "name": "(This is static! Fix !) Harvard Dataverse",
+                        "dataverse_url": "(This is static! Fix !) https://dataverse.harvard.edu"
+                    },
+                    "dataset_name": "(This is static! Fix !) Replication data for: The Supreme Court During Crisis: How War Affects Only Nonwar Cases",
+                    "file_information(This is static! Fix !) ": {
+                        "name": "(This is static! Fix !) crisis.tab",
+                        "fileFormat": "text/tab-separated-values",
+                        "identifier": "https://doi.org/10.7910/DVN/OLD7MB/ZI4N3J",
+                        "description": "Data file for this study"
+                    }
+                }
+            },
+            "statistics": self.release_util.get_release_stats()
+        }
+
+        return self.release_dict
+

--- a/server/opendp_apps/analysis/serializers.py
+++ b/server/opendp_apps/analysis/serializers.py
@@ -192,11 +192,7 @@ class ReleaseValidationSerializer(serializers.ModelSerializer):
         dp_statistics = self.validated_data['dp_statistics']
         # import json; print('dp_statistics', json.dumps(dp_statistics, indent=4))
 
-        #opendp_user = request.user  # is the user in "save(...)" ?
-
-
-        validate_util = ValidateReleaseUtil(opendp_user, analysis_plan_id, dp_statistics)
-        validate_util.run_validation_process()
+        validate_util = ValidateReleaseUtil.validate_mode(opendp_user, analysis_plan_id, dp_statistics)
 
         if validate_util.has_error():
             # This is a big error, check for it before evaluating individual statistics

--- a/server/opendp_apps/analysis/serializers.py
+++ b/server/opendp_apps/analysis/serializers.py
@@ -7,7 +7,6 @@ from django.contrib.auth import get_user_model
 
 from opendp_apps.analysis.models import AnalysisPlan, ReleaseInfo
 from opendp_apps.analysis import static_vals as astatic
-#from opendp_apps.analysis.tools.dp_mean import dp_mean
 from opendp_apps.analysis.validate_release_util import ValidateReleaseUtil
 from opendp_apps.model_helpers.basic_response import ok_resp, err_resp
 
@@ -20,7 +19,7 @@ class AnalysisPlanObjectIdSerializer(serializers.Serializer):
         Check that the object_id belongs to an existing AnalysisPlan object
         """
         try:
-            plan = AnalysisPlan.objects.get(object_id=value)
+            _plan = AnalysisPlan.objects.get(object_id=value)
         except AnalysisPlan.DoesNotExist:
             raise serializers.ValidationError(astatic.ERR_MSG_NO_ANALYSIS_PLAN)
 
@@ -205,7 +204,6 @@ class ReleaseValidationSerializer(serializers.ModelSerializer):
         #print('(validate_util.validation_info)', validate_util.validation_info)
         return ok_resp(validate_util.validation_info)
         #return validate_util.validation_info
-
 
 
 """

--- a/server/opendp_apps/analysis/serializers.py
+++ b/server/opendp_apps/analysis/serializers.py
@@ -147,16 +147,6 @@ class ReleaseValidationSerializer(serializers.ModelSerializer):
         model = ReleaseInfo
         fields = ('dp_statistics', 'analysis_plan_id', )
 
-    # Temp workaround!!! See Issue #300
-    # https://github.com/opendp/dpcreator/issues/300
-    def _camel_to_snake(self, name):
-        """
-        Front end is passing camelCase, but JSON in DB is using snake_case
-        :param name:
-        :return:
-        """
-        return re.sub(r'(?<!^)(?=[A-Z])', '_', name).lower()
-
     def save(self, **kwargs):
         """
         Validate each release request and return any errors that arise.
@@ -206,6 +196,8 @@ class ReleaseValidationSerializer(serializers.ModelSerializer):
 
 
         validate_util = ValidateReleaseUtil(opendp_user, analysis_plan_id, dp_statistics)
+        validate_util.run_validation_process()
+
         if validate_util.has_error():
             # This is a big error, check for it before evaluating individual statistics
             #

--- a/server/opendp_apps/analysis/stat_valid_info.py
+++ b/server/opendp_apps/analysis/stat_valid_info.py
@@ -40,7 +40,7 @@ class StatValidInfo:
         if self.accuracy_val or self.accuracy_msg:
             info['accuracy'] = {}
             if self.accuracy_val:
-                info['accuracy']['val'] = self.accuracy_val
+                info['accuracy']['value'] = self.accuracy_val
             if self.accuracy_msg:
                 info['accuracy']['message'] = self.accuracy_msg
 

--- a/server/opendp_apps/analysis/static_vals.py
+++ b/server/opendp_apps/analysis/static_vals.py
@@ -31,6 +31,8 @@ MISSING_VAL_HANDLING_TYPES = [MISSING_VAL_DROP, MISSING_VAL_INSERT_RANDOM, MISSI
 # --------------------------------------
 # Error Messages
 # --------------------------------------
+ERR_MSG_ANALYSIS_PLAN_NOT_FOUND = 'The AnalysisPlan was not found.'
+
 ERR_MSG_DATASET_ID_REQUIRED = 'The DataSetInfo id is required.'
 ERR_MSG_ANALYSIS_ID_REQUIRED = 'The AnalysisPlan id is required.'
 

--- a/server/opendp_apps/analysis/static_vals.py
+++ b/server/opendp_apps/analysis/static_vals.py
@@ -43,6 +43,8 @@ ERR_MSG_NO_ANALYSIS_PLAN = 'AnalysisPlan object not found for this object_id and
 ERR_MSG_FIELDS_NOT_UPDATEABLE = 'These fields are not updatable'
 
 ERR_MSG_BAD_TOTAL_EPSILON = 'The depositor setup info has an invalid epsilon value'
+ERR_MSG_BAD_TOTAL_DELTA = 'The depositor setup info has an invalid delta value'
+
 ERR_MSG_INVALID_MIN_MAX = 'The "max" must be greater than the "min"'
 
 ERR_IMPUTE_PHRASE_MIN = 'cannot be less than the "min"'

--- a/server/opendp_apps/analysis/testing/__init__.py
+++ b/server/opendp_apps/analysis/testing/__init__.py
@@ -3,4 +3,5 @@ docker-compose run server python manage.py test opendp_apps.analysis.testing.tes
 
 docker-compose run server python manage.py test opendp_apps.analysis.testing.test_dp_mean_spec.StatSpecTest.test_40_test_impute
 
+python manage.py test opendp_apps.analysis.testing.test_run_release
 """

--- a/server/opendp_apps/analysis/testing/test_dp_mean_spec.py
+++ b/server/opendp_apps/analysis/testing/test_dp_mean_spec.py
@@ -70,7 +70,7 @@ class StatSpecTest(TestCase):
                       'ci': astatic.CI_95,
                       #'accuracy': None,
                       'missing_values_handling': astatic.MISSING_VAL_INSERT_FIXED,
-                      'impute_constant': '0',
+                      'fixed_value': '0',
                       'variable_info': {'min': 0,
                                         'max': 100,
                                         'type': 'Float',},
@@ -121,7 +121,7 @@ class StatSpecTest(TestCase):
                       'ci': astatic.CI_95,
                       #'accuracy': None,
                       'missing_values_handling': astatic.MISSING_VAL_INSERT_FIXED,
-                      'impute_constant': '5',
+                      'fixed_value': '5',
                       'variable_info': {'min': -8,
                                         'max': 5,
                                         'type': 'Float',},
@@ -163,7 +163,7 @@ class StatSpecTest(TestCase):
                       'delta': 0.0,
                       'ci': astatic.CI_95,
                       'missing_values_handling': astatic.MISSING_VAL_INSERT_FIXED,
-                      'impute_constant': '5',
+                      'fixed_value': '5',
                       'variable_info': {'min': -8,
                                         'max': 5,
                                         'type': 'Float', },
@@ -202,7 +202,7 @@ class StatSpecTest(TestCase):
                       'delta': 0.0,
                       'ci': astatic.CI_95,
                       'missing_values_handling': astatic.MISSING_VAL_INSERT_FIXED,
-                      'impute_constant': '5',
+                      'fixed_value': '5',
                       'variable_info': {'min': -8,
                                         'max': 5,
                                         'type': 'Float', },
@@ -231,7 +231,7 @@ class StatSpecTest(TestCase):
                       'delta': 0.0,
                       'ci': astatic.CI_95,
                       'missing_values_handling': astatic.MISSING_VAL_INSERT_FIXED,
-                      'impute_constant': '5.0',
+                      'fixed_value': '5.0',
                       'variable_info': {'min': -8,
                                         'max': 5,
                                         'type': 'Float', },
@@ -248,7 +248,7 @@ class StatSpecTest(TestCase):
         for bad_impute, stat_err_msg in bad_impute_info:
             print(f'> bad impute: {bad_impute}')
             new_props = spec_props.copy()
-            new_props['impute_constant'] = bad_impute
+            new_props['fixed_value'] = bad_impute
             dp_mean2 = DPMeanSpec(new_props)
 
             self.assertFalse(dp_mean2.is_chain_valid())
@@ -262,7 +262,7 @@ class StatSpecTest(TestCase):
         for good_impute in good_impute_info:
             print(f'> good impute: {good_impute}')
             new_props = spec_props.copy()
-            new_props['impute_constant'] = good_impute
+            new_props['fixed_value'] = good_impute
             dp_mean = DPMeanSpec(new_props)
             self.assertTrue(dp_mean.is_chain_valid())
 
@@ -283,7 +283,7 @@ class StatSpecTest(TestCase):
                       'ci': astatic.CI_95,
                       #'accuracy': None,
                       'missing_values_handling': astatic.MISSING_VAL_INSERT_FIXED,
-                      'impute_constant': '5',
+                      'fixed_value': '5',
                       'variable_info': {'min': -8,
                                         'max': 5,
                                         'type': 'Float',},

--- a/server/opendp_apps/analysis/testing/test_dp_spec_error.py
+++ b/server/opendp_apps/analysis/testing/test_dp_spec_error.py
@@ -1,0 +1,62 @@
+from django.test.testcases import TestCase
+
+# from unittest import skip
+from opendp_apps.analysis.tools.dp_spec_error import DPSpecError
+
+# from opendp_apps.profiler import static_vals as pstatic
+from opendp_apps.analysis import static_vals as astatic
+
+from opendp_apps.model_helpers.msg_util import msgt
+
+
+class DPSpecErrorTest(TestCase):
+
+    def setUp(self):
+        """Some reusable info"""
+        self.spec_props = {'variable': 'Income',
+                  'col_index': 3,
+                  'statistic': astatic.DP_MEAN,
+                  'dataset_size': 10_000,
+                  'epsilon': 1.0,
+                  'delta': 0.0,
+                  'ci': astatic.CI_95,
+                  #'accuracy': None,
+                  'missing_values_handling': astatic.MISSING_VAL_INSERT_FIXED,
+                  'impute_constant': '45_000',
+                  'variable_info': {'min': 14_000,
+                                    'max': 2_500_000,
+                                    'type': 'Float',},
+                  }
+
+
+    def test_10_min_spec_err(self):
+        """(10) Test minimal DPSpecError"""
+        msgt(self.test_10_min_spec_err.__doc__)
+
+        min_spec_props = dict(error_message='This is a DPSpecError with bare minimal info')
+
+        dp_spec = DPSpecError(min_spec_props)
+        self.assertFalse(dp_spec.is_chain_valid())
+        print(dp_spec.get_error_msg_dict())
+        self.assertEqual(dp_spec.get_error_msg_dict()['valid'], False)
+
+
+    def test_20_min_spec_err(self):
+        """(10) Test DPSpecError with data and error"""
+        msgt(self.test_20_min_spec_err.__doc__)
+
+        self.spec_props['error_message'] = 'This is an error combined with data'
+        dp_spec = DPSpecError(self.spec_props)
+        self.assertFalse(dp_spec.is_chain_valid())
+        print(dp_spec.get_error_msg_dict())
+        self.assertEqual(dp_spec.get_error_msg_dict()['valid'], False)
+
+    def test_30_fail_empty_props(self):
+        """(30) Test DPSpecError with empty {} -- needs at least an "error_message" """
+        msgt(self.test_30_fail_empty_props.__doc__)
+
+        with self.assertRaises(AssertionError) as context:
+            spec_props = {}
+            DPSpecError(spec_props)
+
+            self.assertEqual(str(context.exception) + 'a', DPSpecError.ERR_MSG_REQUIRED_PROPS)

--- a/server/opendp_apps/analysis/testing/test_dp_spec_error.py
+++ b/server/opendp_apps/analysis/testing/test_dp_spec_error.py
@@ -10,6 +10,7 @@ from opendp_apps.model_helpers.msg_util import msgt
 
 
 class DPSpecErrorTest(TestCase):
+    """Some tests for the DPSpecError"""
 
     def setUp(self):
         """Some reusable info"""
@@ -37,6 +38,8 @@ class DPSpecErrorTest(TestCase):
 
         dp_spec = DPSpecError(min_spec_props)
         self.assertFalse(dp_spec.is_chain_valid())
+        self.assertTrue(dp_spec.has_error())
+
         print(dp_spec.get_error_msg_dict())
         self.assertEqual(dp_spec.get_error_msg_dict()['valid'], False)
 
@@ -48,15 +51,19 @@ class DPSpecErrorTest(TestCase):
         self.spec_props['error_message'] = 'This is an error combined with data'
         dp_spec = DPSpecError(self.spec_props)
         self.assertFalse(dp_spec.is_chain_valid())
+        self.assertTrue(dp_spec.has_error())
+
         print(dp_spec.get_error_msg_dict())
         self.assertEqual(dp_spec.get_error_msg_dict()['valid'], False)
 
+
     def test_30_fail_empty_props(self):
-        """(30) Test DPSpecError with empty {} -- needs at least an "error_message" """
+        """(30) Fail with empty constructor"""
+        #   Needs at least 'error_message':
+        #     `spec = DPSpecError(error_message="Something wrong")`
         msgt(self.test_30_fail_empty_props.__doc__)
 
         with self.assertRaises(AssertionError) as context:
-            spec_props = {}
-            DPSpecError(spec_props)
+            DPSpecError({})
 
-            self.assertEqual(str(context.exception) + 'a', DPSpecError.ERR_MSG_REQUIRED_PROPS)
+        self.assertEqual(str(context.exception), DPSpecError.ERR_MSG_REQUIRED_PROPS)

--- a/server/opendp_apps/analysis/testing/test_dp_spec_error.py
+++ b/server/opendp_apps/analysis/testing/test_dp_spec_error.py
@@ -23,7 +23,7 @@ class DPSpecErrorTest(TestCase):
                   'ci': astatic.CI_95,
                   #'accuracy': None,
                   'missing_values_handling': astatic.MISSING_VAL_INSERT_FIXED,
-                  'impute_constant': '45_000',
+                  'fixed_value': '45_000',
                   'variable_info': {'min': 14_000,
                                     'max': 2_500_000,
                                     'type': 'Float',},

--- a/server/opendp_apps/analysis/testing/test_run_release.py
+++ b/server/opendp_apps/analysis/testing/test_run_release.py
@@ -122,15 +122,14 @@ class TestRunRelease(TestCase):
 
         # Send the dp_statistics for validation
         #
-        dp_statistics = self.general_stat_specs
+        analysis_plan.dp_statistics = self.general_stat_specs
+        analysis_plan.save()
 
         # Check the basics
         #
-        release_util = ValidateReleaseUtil(self.user_obj,
-                                           analysis_plan.object_id,
-                                           dp_statistics)
-        # release_util.run_validation_process()
-        release_util.run_release_process()
+        release_util = ValidateReleaseUtil.compute_mode(\
+                               self.user_obj,
+                               analysis_plan.object_id)
 
         self.assertFalse(release_util.has_error())
 

--- a/server/opendp_apps/analysis/testing/test_run_release.py
+++ b/server/opendp_apps/analysis/testing/test_run_release.py
@@ -71,7 +71,7 @@ class TestRunRelease(TestCase):
                             "variable": "TypingSpeed",
                             "epsilon": .5,
                             "delta": 0,
-                            "ci": astatic.CI_95,
+                            "ci": astatic.CI_99,
                             "error": "",
                             "missing_values_handling": astatic.MISSING_VAL_INSERT_FIXED,
                             "handle_as_fixed": False,

--- a/server/opendp_apps/analysis/testing/test_run_release.py
+++ b/server/opendp_apps/analysis/testing/test_run_release.py
@@ -1,0 +1,196 @@
+from os.path import abspath, dirname, isdir, isfile, join
+
+CURRENT_DIR = dirname(abspath(__file__))
+TEST_DATA_DIR = join(dirname(dirname(dirname(CURRENT_DIR))), 'test_data')
+from unittest import skip
+
+import json
+from django.contrib.auth import get_user_model
+from django.core.files import File
+from django.test.testcases import TestCase
+
+from rest_framework.test import APIClient
+
+from opendp_apps.analysis.analysis_plan_util import AnalysisPlanUtil
+from opendp_apps.analysis.models import AnalysisPlan
+from opendp_apps.analysis import static_vals as astatic
+from opendp_apps.analysis.serializers import ReleaseValidationSerializer
+from opendp_apps.analysis.validate_release_util import ValidateReleaseUtil
+from opendp_apps.dataset.models import DataSetInfo
+from opendp_apps.model_helpers.msg_util import msgt
+from opendp_apps.profiler import tasks as profiler_tasks
+from opendp_apps.utils.extra_validators import VALIDATE_MSG_EPSILON
+
+
+class TestRunRelease(TestCase):
+    fixtures = ['test_dataset_data_001.json', ]
+
+    def setUp(self):
+        # test client
+        self.client = APIClient()
+
+        self.user_obj, _created = get_user_model().objects.get_or_create(username='dev_admin')
+
+        self.client.force_login(self.user_obj)
+
+        dataset_info = DataSetInfo.objects.get(id=4)
+        self.add_source_file(dataset_info, 'Fatigue_data.tab', True)
+
+        plan_info = AnalysisPlanUtil.create_plan(dataset_info.object_id, self.user_obj)
+        self.assertTrue(plan_info.success)
+        orig_plan = plan_info.data
+
+        # Retrieve it
+        #
+        self.analysis_plan = AnalysisPlan.objects.first()
+        self.assertEqual(orig_plan.object_id, self.analysis_plan.object_id)
+
+        self.analysis_plan.variable_info['EyeHeight']['min'] = -8.01
+        self.analysis_plan.variable_info['EyeHeight']['max'] = 5
+
+        self.analysis_plan.variable_info['TypingSpeed']['min'] = 3
+        self.analysis_plan.variable_info['TypingSpeed']['max'] = 30
+
+        #analysis_plan.variable_info = variable_info_mod
+        self.analysis_plan.save()
+
+        self.general_stat_specs = [\
+                            {"statistic": astatic.DP_MEAN,
+                              "variable": "EyeHeight",
+                              "epsilon": .45,
+                              "delta": 0,
+                              "ci": astatic.CI_95,
+                              "error": "",
+                              "missing_values_handling": astatic.MISSING_VAL_INSERT_FIXED,
+                              "handle_as_fixed": False,
+                              "fixed_value": "1",
+                              "locked": False,
+                              "label": "EyeHeight"
+                              },
+                           {"statistic": astatic.DP_MEAN,
+                            "variable": "TypingSpeed",
+                            "epsilon": .5,
+                            "delta": 0,
+                            "ci": astatic.CI_95,
+                            "error": "",
+                            "missing_values_handling": astatic.MISSING_VAL_INSERT_FIXED,
+                            "handle_as_fixed": False,
+                            "fixed_value": "9",
+                            "locked": False,
+                            "label": "TypingSpeed"
+                            }
+                         ]
+
+    def add_source_file(self, dataset_info: DataSetInfo, filename: str, add_profile: bool = False) -> DataSetInfo:
+        """Add a source file -- example...
+        - filepath - file under dpcreator/test_data
+        """
+
+        # File to attach: Must be in "dpcreator/test_data"
+        #
+        filepath = join(TEST_DATA_DIR, filename)
+        self.assertTrue(isfile(filepath))
+
+        # Attach the file to the  `dataset_info.source_file` field
+        #
+        django_file = File(open(filepath, 'rb'))
+        dataset_info.source_file.save(filename, django_file)
+        dataset_info.save()
+
+        # If specified, profile the file
+        #
+        if add_profile is True:
+            profile_handler = profiler_tasks.run_profile_by_filefield(dataset_info.object_id)
+            print('profile_handler.has_error()', profile_handler.has_error())
+
+            # Shouldn't have errors
+            if profile_handler.has_error():
+                print(f'!! error: {profile_handler.get_err_msg()}')
+
+            self.assertTrue(profile_handler.has_error() is False)
+
+        # re-retrieve it...
+        return DataSetInfo.objects.get(object_id=dataset_info.object_id)
+
+
+
+    def test_10_validate_stats(self):
+        """(10) Test a working stat"""
+        msgt(self.test_10_validate_stats.__doc__)
+
+        analysis_plan = self.analysis_plan
+
+        # Send the dp_statistics for validation
+        #
+        dp_statistics = self.general_stat_specs
+
+        # Check the basics
+        #
+        release_util = ValidateReleaseUtil(self.user_obj,
+                                           analysis_plan.object_id,
+                                           dp_statistics)
+        # release_util.run_validation_process()
+        release_util.run_release_process()
+
+        self.assertFalse(release_util.has_error())
+
+        release_list = release_util.get_release_stats()
+
+        self.assertEqual(release_list[0]['variable'], 'EyeHeight')
+        self.assertTrue('result' in release_list[0])
+        self.assertTrue('value' in release_list[0]['result'])
+        self.assertTrue(float(release_list[0]['result']['value']))
+
+        self.assertEqual(release_list[1]['variable'], 'TypingSpeed')
+        self.assertTrue('result' in release_list[1])
+        self.assertTrue('value' in release_list[1]['result'])
+        self.assertTrue(float(release_list[1]['result']['value']))
+
+
+    @skip
+    def test_15_api_validate_stats(self):
+        """(15) Test a working stat via API"""
+        msgt(self.test_15_api_validate_stats.__doc__)
+
+        analysis_plan = self.analysis_plan
+
+        # Send the dp_statistics for validation
+        #
+        stat_spec = self.general_stat_spec
+
+        request_plan = dict(analysis_plan_id=str(analysis_plan.object_id),
+                            dp_statistics=[stat_spec])
+
+        response = self.client.post('/api/validation/',
+                                    json.dumps(request_plan),
+                                    content_type='application/json')
+
+        jresp = response.json()
+        self.assertEqual(response.status_code, 200)
+
+        self.assertTrue(jresp['success'])
+
+
+    @skip
+    def test_70_show_add_file(self):
+        """(70) Sample of attaching file to a DataSetInfo object"""
+        msgt(self.test_70_show_add_file.__doc__)
+
+        analysis_plan = self.analysis_plan
+
+        dataset_info_1 = analysis_plan.dataset
+        dataset_info_1.data_profile = None
+        dataset_info_1.profile_variables = None
+        dataset_info_1.save()
+
+        dataset_info_updated = self.add_source_file(analysis_plan.dataset, 'Fatigue_data.tab', True)
+
+        self.assertTrue('variables' in dataset_info_updated.data_profile)
+        self.assertTrue('dataset' in dataset_info_updated.data_profile)
+
+        self.assertTrue('variables' in dataset_info_updated.profile_variables)
+        self.assertTrue('dataset' in dataset_info_updated.profile_variables)
+
+        # print(json.dumps(dataset_info_2.data_profile, indent=4))
+        # print(json.dumps(dataset_info_2.profile_variables, indent=4))
+

--- a/server/opendp_apps/analysis/tests.py
+++ b/server/opendp_apps/analysis/tests.py
@@ -21,12 +21,12 @@ class TestDPMean(TestCase):
 
         col_names = ["A", "B", "C", "D", "E"]
         index = "E"
-        impute_constant = 0.
+        fixed_value = 0.
         lower = 0.
         upper = 10000.
         n = 1000
         epsilon = 1.
         preprocessor = make_split_dataframe(separator=",", col_names=col_names)
-        res = preprocessor >> dp_mean(index, lower, upper, n, impute_constant, epsilon=epsilon)
+        res = preprocessor >> dp_mean(index, lower, upper, n, fixed_value, epsilon=epsilon)
         dp_mean_value = res(data)
         self.assertEqual(type(dp_mean_value), float)

--- a/server/opendp_apps/analysis/tools/dp_mean_spec.py
+++ b/server/opendp_apps/analysis/tools/dp_mean_spec.py
@@ -33,7 +33,7 @@ class DPMeanSpec(StatSpec):
                       dataset_size=365,
                       epsilon=0.5,
                       ci=CI_95.
-                      impute_constant=1)
+                      fixed_value=1)
     """
     def __init__(self, props: dict):
         """Set the internals using the props dict"""
@@ -44,20 +44,20 @@ class DPMeanSpec(StatSpec):
         Add a list of required properties
         example: ['min', 'max']
         """
-        return ['min', 'max', 'ci',]    # 'impute_constant']
+        return ['min', 'max', 'ci',]    # 'fixed_value']
 
     def run_01_initial_handling(self):
         """
         Make sure values are consistently floats
         """
-        if self.impute_constant is not None:
+        if self.fixed_value is not None:
             pass
 
         # Use the "impute_value" for missing values, make sure it's a float!
         #
         if self.missing_values_handling == astatic.MISSING_VAL_INSERT_FIXED:
             # Convert the impute value to a float!
-            if not self.convert_to_float('impute_constant'):
+            if not self.convert_to_float('fixed_value'):
                 return
         self.floatify_int_values()
 
@@ -66,12 +66,12 @@ class DPMeanSpec(StatSpec):
         This is a place for initial checking/transformations
         such as making sure values are floats
         Example:
-        self.check_numeric_impute_constant()
+        self.check_numeric_fixed_value()
         """
         if self.has_error():
             return
 
-        self.check_numeric_impute_constant()
+        self.check_numeric_fixed_value()
 
     def check_scale(self, scale, preprocessor, dataset_distance, epsilon):
         """
@@ -104,10 +104,10 @@ class DPMeanSpec(StatSpec):
             # Cast the column as Vec<Optional<Float>>
             make_cast(TIA=str, TOA=float) >>
             # Impute missing values to 0 Vec<Float>
-            make_impute_constant(self.impute_constant) >>
+            make_impute_constant(self.fixed_value) >>
             # Clamp age values
             make_clamp(self.get_bounds()) >>
-            make_bounded_resize(self.dataset_size, self.get_bounds(), self.impute_constant) >>
+            make_bounded_resize(self.dataset_size, self.get_bounds(), self.fixed_value) >>
             make_sized_bounded_mean(self.dataset_size, self.get_bounds())
         )
 

--- a/server/opendp_apps/analysis/tools/dp_mean_spec.py
+++ b/server/opendp_apps/analysis/tools/dp_mean_spec.py
@@ -46,7 +46,7 @@ class DPMeanSpec(StatSpec):
         """
         return ['min', 'max', 'ci',]    # 'impute_constant']
 
-    def run_initial_handling(self):
+    def run_01_initial_handling(self):
         """
         Make sure values are consistently floats
         """
@@ -61,7 +61,7 @@ class DPMeanSpec(StatSpec):
                 return
         self.floatify_int_values()
 
-    def run_custom_validation(self):
+    def run_03_custom_validation(self):
         """
         This is a place for initial checking/transformations
         such as making sure values are floats

--- a/server/opendp_apps/analysis/tools/dp_spec_error.py
+++ b/server/opendp_apps/analysis/tools/dp_spec_error.py
@@ -1,6 +1,21 @@
 """
 This has the required interface as StatSpec but is only used to hold
-a spec-level error -- nothing else works!
+a spec-level error when there isn't enough info for a minimal spec
+
+It simply holds an error message. If you also send data, it skips any validation.
+
+Minimal example: `spec = DPSpecError(error_message="Something wrong")`
+
+With other props:
+    props = {
+             "error_message": "Couldn't find variable_info",  # required!
+             "variable": "education_level",
+             "statistic": DP_MEAN,
+             "epsilon": 0.25,
+             #.... (as much as more info as desired) ...
+             }
+    spec = DPSpecError(props)     # skips all validation and sets `self.error_found = True`
+
 """
 from opendp_apps.analysis.tools.stat_spec import StatSpec
 from opendp_apps.analysis import static_vals as astatic
@@ -24,8 +39,7 @@ class DPSpecError(StatSpec):
 
         assert 'error_message' in props, self.ERR_MSG_REQUIRED_PROPS
 
-
-        self.add_err_msg(props['error_message'])
+        self.add_err_msg(props['error_message'])    # Sets `self.error_found = True`
 
 
     def run_basic_validation(self):

--- a/server/opendp_apps/analysis/tools/dp_spec_error.py
+++ b/server/opendp_apps/analysis/tools/dp_spec_error.py
@@ -42,7 +42,7 @@ class DPSpecError(StatSpec):
         self.add_err_msg(props['error_message'])    # Sets `self.error_found = True`
 
 
-    def run_basic_validation(self):
+    def run_02_basic_validation(self):
         """Unusual override!!!"""
         pass
 
@@ -54,10 +54,10 @@ class DPSpecError(StatSpec):
     def additional_required_props(self):
         return []
 
-    def run_initial_handling(self):
+    def run_01_initial_handling(self):
         pass
 
-    def run_custom_validation(self):
+    def run_03_custom_validation(self):
         pass
 
     def check_scale(self, scale, preprocessor, dataset_distance):

--- a/server/opendp_apps/analysis/tools/dp_spec_error.py
+++ b/server/opendp_apps/analysis/tools/dp_spec_error.py
@@ -1,0 +1,59 @@
+"""
+This has the required interface as StatSpec but is only used to hold
+a spec-level error -- nothing else works!
+"""
+from opendp_apps.analysis.tools.stat_spec import StatSpec
+from opendp_apps.analysis import static_vals as astatic
+
+
+class DPSpecError(StatSpec):
+
+    ERR_MSG_REQUIRED_PROPS = ('It is required that "props" has an "error_message".'
+                              'e.g.: `spec = DPSpecError(error_message="Something wrong")`')
+    """
+    This is used to hold an error message!
+    """
+    def __init__(self, props: dict):
+        """
+        Minimum format for props
+        {
+            "error_message": "The error to send to the user"
+        }
+        """
+        super().__init__(props)
+
+        assert 'error_message' in props, self.ERR_MSG_REQUIRED_PROPS
+
+
+        self.add_err_msg(props['error_message'])
+
+
+    def run_basic_validation(self):
+        """Unusual override!!!"""
+        pass
+
+    #
+    # The methods below fields are required, e.g. @abc.abstract
+    #   on the parent class
+    #
+
+    def additional_required_props(self):
+        return []
+
+    def run_initial_handling(self):
+        pass
+
+    def run_custom_validation(self):
+        pass
+
+    def check_scale(self, scale, preprocessor, dataset_distance):
+        pass
+
+    def get_preprocessor(self):
+        return None
+
+    def run_chain(self, columns: list, file_obj, sep_char=","):
+        return False
+
+    def set_accuracy(self):
+        pass

--- a/server/opendp_apps/analysis/tools/stat_spec.py
+++ b/server/opendp_apps/analysis/tools/stat_spec.py
@@ -407,6 +407,51 @@ class StatSpec:
         #for key, val in self.__dict__.items():
         #    print(f'{key}: {val}')
 
+
+    def get_release_dict(self):
+        """Final release info"""
+        assert not self.has_error(), \
+            'Do not call this method before checking that ".has_error()" is False'
+        assert self.value, \
+            'Only use this after "run_chain()" was completed successfully"'
+
+        final_info = {
+             "statistic": self.statistic,
+             "variable": self.variable,
+             "result":{
+                "value": self.value
+             },
+             "epsilon": self.epsilon,
+             "delta": self.delta,
+        }
+
+        # Min/Max
+        #
+        if 'min' in self.additional_required_props():
+            final_info['bounds'] = {'min': self.min, 'max': self.max}
+
+        # Categories
+        #
+        if 'categories' in self.additional_required_props():
+            final_info['categories'] = self.categories
+
+        # Missing values
+        #
+        final_info['missing_value_handling'] = {"type": self.missing_values_handling}
+        if self.missing_values_handling == astatic.MISSING_VAL_INSERT_FIXED:
+            final_info['missing_value_handling']['impute_constant'] = self.impute_constant
+
+        # Add accuracy
+        #
+        if self.accuracy_val or self.accuracy_msg:
+            final_info['confidence_interval'] = self.ci
+            final_info['accuracy'] = {}
+            if self.accuracy_val:
+                final_info['accuracy']['value'] = self.accuracy_val
+            if self.accuracy_msg:
+                final_info['accuracy']['message'] = self.accuracy_msg
+
+
     def has_error(self):
         """Did an error occur?"""
         return self.error_found

--- a/server/opendp_apps/analysis/tools/stat_spec.py
+++ b/server/opendp_apps/analysis/tools/stat_spec.py
@@ -397,7 +397,13 @@ class StatSpec:
         """Get invalid info dict"""
         return StatValidInfo.get_error_msg_dict(self.variable,
                                                 self.statistic,
-                                                self.get_err_msgs()[0])
+                                                self.get_single_err_msg())
+
+    def get_single_err_msg(self):
+        """Get the first message in the self.error_messages list"""
+        if self.has_error():
+            return self.get_err_msgs()[0]
+        return None
 
     def print_debug(self):
         """show params"""

--- a/server/opendp_apps/analysis/tools/stat_spec.py
+++ b/server/opendp_apps/analysis/tools/stat_spec.py
@@ -87,9 +87,9 @@ class StatSpec:
         self.error_found = False
         self.error_messages = []
 
-        self.run_initial_handling()     # customize, if types need converting, etc.
-        self.run_basic_validation()     # always the same
-        self.run_custom_validation()    # customize, if types need converting, etc.
+        self.run_01_initial_handling()     # customize, if types need converting, etc.
+        self.run_02_basic_validation()     # always the same
+        self.run_03_custom_validation()    # customize, if types need converting, etc.
 
 
     @abc.abstractmethod
@@ -102,7 +102,7 @@ class StatSpec:
         raise NotImplementedError('additional_required_props')
 
     @abc.abstractmethod
-    def run_initial_handling(self):
+    def run_01_initial_handling(self):
         """
         This is a place for initial checking/transformations
         such as making sure values are floats
@@ -117,12 +117,12 @@ class StatSpec:
             return
 
         """
-        raise NotImplementedError('run_initial_handling')
+        raise NotImplementedError('run_01_initial_handling')
 
     @abc.abstractmethod
-    def run_custom_validation(self):
+    def run_03_custom_validation(self):
         """
-        This is a place for initial checking/transformations
+        This is a place for custom checking/transformations
         such as making sure values are floats
 
         See "dp_mean_spec.py for an example of instantiation
@@ -138,7 +138,7 @@ class StatSpec:
         pass
         ```
         """
-        raise NotImplementedError('run_custom_validation')
+        raise NotImplementedError('run_03_custom_validation')
 
 
     @abc.abstractmethod
@@ -276,9 +276,9 @@ class StatSpec:
             if not self.convert_to_float(prop_name):
                 return
 
-    def run_basic_validation(self):
+    def run_02_basic_validation(self):
         """Evaluate the properties, make sure they are populated"""
-        if self.has_error():   # something may be wrong in "run_initial_handling()"
+        if self.has_error():   # something may be wrong in "run_01_initial_handling()"
             return
 
         # Always validate these properties, mostly using the self.prop_validators

--- a/server/opendp_apps/analysis/tools/stat_spec.py
+++ b/server/opendp_apps/analysis/tools/stat_spec.py
@@ -448,8 +448,10 @@ class StatSpec:
             final_info['accuracy'] = {}
             if self.accuracy_val:
                 final_info['accuracy']['value'] = self.accuracy_val
-            if self.accuracy_msg:
-                final_info['accuracy']['message'] = self.accuracy_msg
+            if self.accuracy_message:
+                final_info['accuracy']['message'] = self.accuracy_message
+
+        return final_info
 
 
     def has_error(self):

--- a/server/opendp_apps/analysis/tools/stat_spec.py
+++ b/server/opendp_apps/analysis/tools/stat_spec.py
@@ -48,7 +48,7 @@ class StatSpec:
                            categories=validate_not_empty_or_none,  # ?
                            #
                            missing_values_handling=validate_missing_val_handlers,
-                           #impute_constant=validate_not_none, # more complex check
+                           #fixed_value=validate_not_none, # more complex check
                            #fixed_value=
                            #
                            accuracy=validate_not_negative)
@@ -68,7 +68,7 @@ class StatSpec:
         self.accuracy_message = None
         #
         self.missing_values_handling = props.get('missing_values_handling')
-        self.impute_constant = props.get('impute_constant')
+        self.fixed_value = props.get('fixed_value')
         #self.missing_fixed_val = props.get('missing_fixed_val')
         #
         # Note: min, max, categories are sent in via variable_info
@@ -320,25 +320,25 @@ class StatSpec:
         # If this is numeric variable, check the impute constant
         #   (If impute constant isn't used, this check will simply exit)
         #if self.var_type in pstatic.NUMERIC_VAR_TYPES:
-        #    self.check_numeric_impute_constant()
+        #    self.check_numeric_fixed_value()
 
-    def check_numeric_impute_constant(self):
+    def check_numeric_fixed_value(self):
         """
         For the case of handing missing values with a constant
-        Check that the fixed value/impute_constant is not outside the min/max range
+        Check that the fixed value/fixed_value is not outside the min/max range
         """
         if self.has_error():
             return
 
         if self.missing_values_handling == astatic.MISSING_VAL_INSERT_FIXED:
 
-            if self.impute_constant < self.min:
-                user_msg = (f'The "fixed value" ({self.impute_constant})'
+            if self.fixed_value < self.min:
+                user_msg = (f'The "fixed value" ({self.fixed_value})'
                             f' {astatic.ERR_IMPUTE_PHRASE_MIN} ({self.min})')
                 self.add_err_msg(user_msg)
                 return
-            elif self.impute_constant > self.max:
-                user_msg = (f'The "fixed value" ({self.impute_constant})'
+            elif self.fixed_value > self.max:
+                user_msg = (f'The "fixed value" ({self.fixed_value})'
                             f' {astatic.ERR_IMPUTE_PHRASE_MAX} ({self.max})')
                 self.add_err_msg(user_msg)
                 return
@@ -439,7 +439,7 @@ class StatSpec:
         #
         final_info['missing_value_handling'] = {"type": self.missing_values_handling}
         if self.missing_values_handling == astatic.MISSING_VAL_INSERT_FIXED:
-            final_info['missing_value_handling']['impute_constant'] = self.impute_constant
+            final_info['missing_value_handling']['fixed_value'] = self.fixed_value
 
         # Add accuracy
         #

--- a/server/opendp_apps/analysis/tools/xdp_mean.py
+++ b/server/opendp_apps/analysis/tools/xdp_mean.py
@@ -4,7 +4,7 @@ from opendp.meas import *
 enable_features("floating-point")
 
 
-def dp_mean(index, lower, upper, n, impute_constant, epsilon):
+def dp_mean(index, lower, upper, n, fixed_value, epsilon):
     """
     Interface to calculate a DP Mean of a column. Note that this does not
     read the data set, this must be done beforehand (see analysis.tests for
@@ -13,7 +13,7 @@ def dp_mean(index, lower, upper, n, impute_constant, epsilon):
     :param lower:
     :param upper:
     :param n:
-    :param impute_constant:
+    :param fixed_value:
     :param epsilon:
     :return:
     """
@@ -37,10 +37,10 @@ def dp_mean(index, lower, upper, n, impute_constant, epsilon):
         # Cast the column as Vec<Optional<Float>>
         make_cast(TIA=str, TOA=float) >>
         # Impute missing values to 0 Vec<Float>
-        make_impute_constant(impute_constant) >>
+        make_impute_constant(fixed_value) >>
         # Clamp age values
         make_clamp(bounds) >>
-        make_bounded_resize(n, bounds, impute_constant) >>
+        make_bounded_resize(n, bounds, fixed_value) >>
         make_sized_bounded_mean(n, bounds)
 
         #make_bounded_mean(lower, upper, n=n, T=float)

--- a/server/opendp_apps/analysis/validate_release_util.py
+++ b/server/opendp_apps/analysis/validate_release_util.py
@@ -219,7 +219,6 @@ class ValidateReleaseUtil(BasicErrCheck):
             # -------------------------------------
             props = dp_stat         # start with what is in dp_stat--the UI input
             props['dataset_size'] = self.dataset_size   # add dataset size
-            props['impute_constant'] = dp_stat.get('fixed_value') # one bit of renaming!
 
             #  Some high-level error checks, before making the StatSpec
             #

--- a/server/opendp_apps/analysis/validate_release_util.py
+++ b/server/opendp_apps/analysis/validate_release_util.py
@@ -112,7 +112,8 @@ class ValidateReleaseUtil(BasicErrCheck):
         #   - Fail on 1st error found
         for stat_spec in self.stat_spec_list:
             if stat_spec.has_error():
-                user_msg = (f'Validation error found for {stat_spec.statistic}:'
+                user_msg = (f'Validation error found for variable "{stat_spec.variable}"'
+                            f' and statistic "{stat_spec.statistic}":'
                             f' {stat_spec.get_single_err_msg()}')
                 self.add_err_msg(user_msg)
                 return

--- a/server/opendp_apps/analysis/validate_release_util.py
+++ b/server/opendp_apps/analysis/validate_release_util.py
@@ -56,19 +56,12 @@ class ValidateReleaseUtil(BasicErrCheck):
 
         self.opendp_version = pkg_resources.get_distribution('opendp').version
 
-        self.run_validation_process()
-
-        if release_run:
-            pass
-            # do some more stuff
-            # self.run_release()
-
+        # self.run_validation_process()
 
 
     def add_stat_spec(self, stat_spec: StatSpec):
         """Add a StatSpec subclass to a list"""
         self.stat_spec_list.append(stat_spec)
-
 
     def run_release_process(self):
         """Run the release process"""

--- a/server/opendp_apps/analysis/views/release_view.py
+++ b/server/opendp_apps/analysis/views/release_view.py
@@ -43,31 +43,7 @@ class ReleaseView(viewsets.ViewSet):
                     "success": true,
                     "message": "release worked!",
                     "data":
-                        [
-                          {
-                              "statistic": "mean",
-                              "variable": "EyeHeight",
-                              "result": {
-                                  "value": -1.171651194916809
-                              },
-                              "epsilon": 0.45,
-                              "delta": 0,
-                              "bounds": {
-                                  "min": -8.01,
-                                  "max": 5.0
-                              },
-                              "missing_value_handling": {
-                                  "type": "insert_fixed",
-                                  "impute_constant": 1.0
-                              },
-                              "confidence_interval": 0.05,
-                              "accuracy": {
-                                  "value": 0.4732784077797872,
-                                  "message": "Releasing mean for the variable EyeHeight. With at least probability 0.95 the output mean will differ from the true mean by at most 0.4732784077797872 units. Here the units are the same units the variable has in the dataset."
-                              }
-                          },
-                        ]
-            }
+                       (see: opendp_apps.release_info_formatter.get_release_data())
 
         """
         # Get the AnalysisPlan object_id

--- a/server/opendp_apps/analysis/views/release_view.py
+++ b/server/opendp_apps/analysis/views/release_view.py
@@ -1,22 +1,106 @@
-from rest_framework import viewsets, status
+from rest_framework import permissions, viewsets, status
 from rest_framework.response import Response
 from opendp_apps.utils.view_helper import get_json_error, get_json_success
 
-from opendp_apps.analysis.serializers import AnalysisPlanSerializer, \
-    ReleaseValidationSerializer, ComputationChainSerializer
+from opendp_apps.analysis.models import AnalysisPlan
+from opendp_apps.analysis.validate_release_util import ValidateReleaseUtil
+from opendp_apps.analysis.serializers import AnalysisPlanObjectIdSerializer, AnalysisPlanSerializer
 
 
 class ReleaseView(viewsets.ViewSet):
 
-    statistics = ReleaseValidationSerializer()
     analysis_plan = AnalysisPlanSerializer()
+    permission_classes = [permissions.IsAuthenticated]
+    http_method_names = ['post']    # 'patch']
 
-    http_method_names = ['get', 'post', 'patch']
+    def get_queryset(self):
+        """
+        AnalysisPlans for the currently authenticated user.
+        """
+        return AnalysisPlan.objects.filter(analyst=self.request.user)
 
-    def create(self, request, object_id=None):
-        # TODO: This maybe should be under the POST method but with a flag (validation=false actually runs the chain)
-        computation_chain_serializer = ComputationChainSerializer(data=request.data)
-        if not computation_chain_serializer.is_valid():
-            raise Exception(f"Invalid Computation Chain request: {computation_chain_serializer.errors}")
-        results = computation_chain_serializer.run_computation_chain()
-        return Response({'results': results}, status=status.HTTP_201_CREATED)
+
+    def create(self, request, *args, **kwargs):
+        """
+        Override create to create a release based on a saved/pre-validated AnalysisPlan.dp_statistics
+
+        endpoint: /api/release/
+
+        Example POST input: `{"analysis_plan_id": "616b5167-4ce8-4def-85dc-6f0d8de2316c"}`
+
+       -- Example outputs --
+
+        (1) Overall error
+            Status code: 400
+                {
+                    "success": false,
+                    "message": "The statistic 'EyeHeight' had error xyz!"
+                }
+
+        (2) Release success
+            Status code: 201
+            {
+                    "success": true,
+                    "message": "release worked!",
+                    "data":
+                        [
+                          {
+                              "statistic": "mean",
+                              "variable": "EyeHeight",
+                              "result": {
+                                  "value": -1.171651194916809
+                              },
+                              "epsilon": 0.45,
+                              "delta": 0,
+                              "bounds": {
+                                  "min": -8.01,
+                                  "max": 5.0
+                              },
+                              "missing_value_handling": {
+                                  "type": "insert_fixed",
+                                  "impute_constant": 1.0
+                              },
+                              "confidence_interval": 0.05,
+                              "accuracy": {
+                                  "value": 0.4732784077797872,
+                                  "message": "Releasing mean for the variable EyeHeight. With at least probability 0.95 the output mean will differ from the true mean by at most 0.4732784077797872 units. Here the units are the same units the variable has in the dataset."
+                              }
+                          },
+                        ]
+            }
+
+        """
+        # Get the AnalysisPlan object_id
+        #   - Bit redundant in the serializer re: retrieving plan but only using object_id--but okay!
+        #     - e.g. Passing along the object_id only will lead to later running chain
+        #       in a separate process and responding by websocket/lambda, etc.
+        #
+        serializer = AnalysisPlanObjectIdSerializer(data=request.data)
+        if not serializer.is_valid():
+            print(serializer.errors)
+            if 'object_id' in serializer.errors:
+                user_msg = '"object_id" error: %s' % (serializer.errors['object_id'][0])
+            else:
+                user_msg = 'Not a valid AnalysisPlan "object_id"'
+            return Response(get_json_error(user_msg),
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        # We have a good object_id!
+        #
+        analysis_plan_id = serializer.get_object_id()
+
+        validate_util = ValidateReleaseUtil.compute_mode(request.user, analysis_plan_id)
+        if validate_util.has_error():
+            # This is a big error, check for it before evaluating individual statistics
+            #
+            user_msg = validate_util.get_err_msg()
+
+            # Can you return a 400 / raise an Exception here with the error message?
+            # How should this be used?
+            return Response(get_json_error(user_msg), status=status.HTTP_400_BAD_REQUEST)
+
+        # It worked! Return the release!
+        release_info_obj = validate_util.get_new_release_info_object()
+        return Response(get_json_success('Release created!',
+                                         data=release_info_obj.dp_release),
+                        status=status.HTTP_201_CREATED)

--- a/server/opendp_apps/analysis/views/validation_view.py
+++ b/server/opendp_apps/analysis/views/validation_view.py
@@ -124,6 +124,3 @@ class ValidationView(viewsets.ViewSet):
         return Response(get_json_success('validation results returned',
                                          data=save_result.data),
                         status=status.HTTP_200_OK)
-
-        #print('stats_valid', stats_valid)
-        #return Response({'valid': stats_valid}, status=status.HTTP_201_CREATED)

--- a/server/opendp_apps/dataset/tests/test_validation_view_and_serializers.py
+++ b/server/opendp_apps/dataset/tests/test_validation_view_and_serializers.py
@@ -161,14 +161,14 @@ class TestValidationViewAndSerializers(TestCase):
         expected_result = [{'variable': 'EyeHeight', 'statistic': 'mean', 'valid': True,
                             'message': None,
                             'accuracy': {
-                                'val': 1.6370121873967791,
+                                'value': 1.6370121873967791,
                                 'message': 'Releasing mean for the variable EyeHeight. With at least probability 0.95 the output mean will differ from the true mean by at most 1.6370121873967791 units. Here the units are the same units the variable has in the dataset.'}}]
 
         #print('stats_info.data', stats_info.data)
         self.assertEqual(stats_info.data[0]['valid'], True)
 
         # Were accuracy results included?
-        self.assertTrue('val' in stats_info.data[0]['accuracy'])
+        self.assertTrue('value' in stats_info.data[0]['accuracy'])
         self.assertTrue('message' in stats_info.data[0]['accuracy'])
 
         accuracy_msg = f'output {astatic.DP_MEAN} will differ from the true {astatic.DP_MEAN} by at'

--- a/server/opendp_apps/dataset/tests/test_validation_view_and_serializers.py
+++ b/server/opendp_apps/dataset/tests/test_validation_view_and_serializers.py
@@ -18,6 +18,7 @@ from opendp_apps.analysis.serializers import ReleaseValidationSerializer
 from opendp_apps.dataset.models import DataSetInfo
 from opendp_apps.model_helpers.msg_util import msgt
 from opendp_apps.profiler import tasks as profiler_tasks
+from opendp_apps.utils.extra_validators import VALIDATE_MSG_EPSILON
 
 
 
@@ -375,9 +376,9 @@ class TestValidationViewAndSerializers(TestCase):
         #
         stats_valid = serializer.save(**dict(opendp_user=self.user_obj))
         self.assertTrue(stats_valid.success)
-
+        print('40!! stats_valid', stats_valid.data)
         self.assertEqual(stats_valid.data[0]['valid'], False)
-        self.assertTrue(stats_valid.data[0]['message'].find('exceeds max epsilon') > -1)
+        self.assertTrue(stats_valid.data[0]['message'].find(VALIDATE_MSG_EPSILON) > -1)
 
     def test_45_api_fail_single_stat_bad_epsilon(self):
         """(45) Fail: API, Single stat exceeds total epsilon"""
@@ -419,7 +420,7 @@ class TestValidationViewAndSerializers(TestCase):
         print('jresp', jresp)
 
         self.assertEqual(jresp['data'][0]['valid'], False)
-        self.assertTrue(jresp['data'][0]['message'].find('exceeds max epsilon') > -1)
+        self.assertTrue(jresp['data'][0]['message'].find(VALIDATE_MSG_EPSILON) > -1)
 
 
     def test_50_bad_total_epsilon(self):
@@ -614,8 +615,6 @@ class TestValidationViewAndSerializers(TestCase):
         msgt(self.test_80_fail_impute_too_low.__doc__)
 
         analysis_plan = self.analysis_plan
-
-        print('analysis_plan.variable_info', analysis_plan.variable_info)
 
         # invalid min/max
         analysis_plan.variable_info['EyeHeight']['min'] = -8

--- a/server/opendp_apps/dataset/tests/test_validation_view_and_serializers.py
+++ b/server/opendp_apps/dataset/tests/test_validation_view_and_serializers.py
@@ -224,13 +224,10 @@ class TestValidationViewAndSerializers(TestCase):
         #print('stats_info.success', stats_info.success)
         self.assertTrue(stats_info.success)
 
-        #print('stats_info.data', stats_info.data)
-        expected_result = [ \
-                {'variable': 'EyeHeight', 'statistic': astatic.DP_SUM, 'valid': False,
-                  'message': 'Statistic "sum" will be supported soon!'}]
-
-        self.assertEqual(expected_result, stats_info.data)
-
+        self.assertEqual(stats_info.data[0]['valid'], False)
+        self.assertEqual(stats_info.data[0]['statistic'], astatic.DP_SUM)
+        self.assertEqual(stats_info.data[0]['variable'], 'EyeHeight')
+        self.assertEqual(stats_info.data[0]['message'], 'Statistic "sum" will be supported soon!')
 
     def test_25_api_fail_unsupported_stat(self):
         """(25) Fail: API, Test a known but unsupported statistic"""
@@ -256,11 +253,10 @@ class TestValidationViewAndSerializers(TestCase):
 
         self.assertTrue(jresp['success'])
 
-        expected_result = [ \
-                {'variable': 'EyeHeight', 'statistic': astatic.DP_SUM, 'valid': False,
-                  'message': 'Statistic "sum" will be supported soon!'}]
-
-        self.assertEqual(expected_result, jresp['data'])
+        self.assertEqual(jresp['data'][0]['valid'], False)
+        self.assertEqual(jresp['data'][0]['statistic'], astatic.DP_SUM)
+        self.assertEqual(jresp['data'][0]['variable'], 'EyeHeight')
+        self.assertEqual(jresp['data'][0]['message'], 'Statistic "sum" will be supported soon!')
 
 
     def test_30_fail_bad_min_max(self):

--- a/server/opendp_apps/utils/extra_validators.py
+++ b/server/opendp_apps/utils/extra_validators.py
@@ -110,6 +110,8 @@ def validate_float(value):
         float(value)
     except ValueError:
         raise ValidationError(VALIDATE_MSG_NOT_FLOAT)
+    except TypeError:
+        raise ValidationError(VALIDATE_MSG_NOT_FLOAT)
 
 """
 from opendp_apps.utils.extra_validators import *

--- a/server/opendp_apps/utils/extra_validators.py
+++ b/server/opendp_apps/utils/extra_validators.py
@@ -38,6 +38,8 @@ def validate_missing_val_handlers(value):
 
 def validate_not_negative(value):
     """Valid values are non-negative numbers"""
+    validate_float(value)
+
     if value < 0.0:
         raise ValidationError(VALIDATE_MSG_ZERO_OR_GREATER)
 


### PR DESCRIPTION
With the analysis plan and dp_statistic specs from the user:

- Build a list of StatSpec objects: `stat_spec_list = [] `
- Iterate through for validation:

```python
# validation...
for stat_spec in self.stat_spec_list:
    if stat_spec.is_chain_valid():
        pass  # looks good
    else:
        pass  # uh oh!
        
# computation... (after validation)
for stat_spec in self.stat_spec_list:
    stat_spec.run_chain(col_indexes, file_handle, sep_char=sep_char)
    if stat_spec.has_error()
        pass # do something (error), throw out any previous stats
    else:
        pass  # looks good!
```