### PR TITLE
update demo fixtures with new dataset info from test dataverse

### DIFF
--- a/client/cypress/fixtures/PUMSDemoData.json
+++ b/client/cypress/fixtures/PUMSDemoData.json
@@ -1,5 +1,5 @@
 {
-  "datasetName": "2000 PUMS 5-Percent",
+  "datasetName": "Demo PUMS 5-Percent",
   "variables": {
     "age": {
       "name": "age",

--- a/client/cypress/fixtures/PUMSMockDV.json
+++ b/client/cypress/fixtures/PUMSMockDV.json
@@ -1,9 +1,9 @@
 {
   "siteUrl": "http://ec2-18-232-125-211.compute-1.amazonaws.com",
-  "fileId": "13",
-  "datasetPid": "doi:10.5072/FK2/QWVFK0",
+  "fileId": "15",
+  "datasetPid": "doi:10.5072/FK2/GE8HA9",
   "token": "c7af4204-bbbf-44b8-a3e5-a37ba34c24dc",
-  "filePid": "doi:10.5072/FK2/QWVFK0",
+  "filePid": "doi:10.5072/FK2/GE8HA9",
   "user": "test_user",
   "password": "dpcreator"
 }

--- a/client/cypress/support/commands.js
+++ b/client/cypress/support/commands.js
@@ -131,11 +131,11 @@ Cypress.Commands.add('testMean', (numericVar) => {
 
     // Continue to Create  Statistics Step
     cy.get('[data-test="wizardContinueButton"]').last().click();
-    cy.intercept('POST', '/api/analyze/**',).as(
-        'createPlan'
-    )
+    // On the statistics page,
+    cy.get('h1').should('contain', 'Create the statistics').should('be.visible')
+    cy.get('[data-test="wizardContinueButton"]').should('be.enabled')
 
-    cy.wait('@createPlan', {timeout: 10000})
+
     // Test Validating EyeHeight mean
     cy.get('[data-test="Add Statistic"]').click({force: true});
     cy.get('[data-test="Mean"]').click({force: true});
@@ -169,16 +169,3 @@ Cypress.Commands.add('testMean', (numericVar) => {
     cy.get('[data-test="statistic description"]').should('contain', snippet)
 
 })
-
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })


### PR DESCRIPTION
also wait for DOM element to be visible before creating a statistic. I think this will fix the timing related cypress test failures.