### PR TITLE
For #374, separate LaTeX image building into two Dockerfiles

### DIFF
--- a/latex_service/Dockerfile
+++ b/latex_service/Dockerfile
@@ -1,9 +1,13 @@
-FROM python:3.9
+# Base image includes Python 3.9 and TeX Live package
+FROM ghcr.io/opendp/dpcreator/texlive-base:latest
 
-ENV PYTHONUNBUFFERED=1
+MAINTAINER OpenDP https://github.com/opendp
 
-RUN apt-get update && apt-get install -y \
-  texlive-full
+LABEL organization="OpenDP" \
+      version="0.1-alpha" \
+      release-date="2022-10-14" \
+      description="DP Creator LaTeX service"
+
 # -------------------------------------
 # Copy over the requirements and run them
 # -------------------------------------

--- a/latex_service/Dockerfile-texlive-base
+++ b/latex_service/Dockerfile-texlive-base
@@ -1,0 +1,22 @@
+# -----------------------------------------------------
+# This Dockerfile is used to create an image providing
+#  - Python 3.9
+#  - The Tex Live system (https://www.tug.org/texlive/)
+#
+# It is built up on by subsequent images such as
+#   the DP Creator LaTeX service
+# -----------------------------------------------------
+FROM python:3.9
+
+MAINTAINER OpenDP https://github.com/opendp
+
+LABEL organization="OpenDP" \
+      version="0.1-alpha" \
+      release-date="2022-10-14" \
+      description="Base image with Python 3.9 and LaTeX for the DP Creator LaTeX service"
+
+
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update && \
+    apt-get install -y texlive-full

--- a/latex_service/Dockerfile-texlive-base
+++ b/latex_service/Dockerfile-texlive-base
@@ -13,7 +13,7 @@ MAINTAINER OpenDP https://github.com/opendp
 LABEL organization="OpenDP" \
       version="0.1-alpha" \
       release-date="2022-10-14" \
-      description="Base image with Python 3.9 and LaTeX for the DP Creator LaTeX service"
+      description="Base image with Python 3.9 and Tex Live for the DP Creator LaTeX service"
 
 
 ENV PYTHONUNBUFFERED=1

--- a/latex_service/README.md
+++ b/latex_service/README.md
@@ -1,0 +1,20 @@
+# LaTeX Service for DP Creator
+
+## Build the Docker Images
+
+### Build the dpcreator/texlive-base image
+
+```
+# From within the ./latex_service directory
+#
+docker build -t ghcr.io/opendp/dpcreator/texlive-base:latest -f Dockerfile-texlive-base .
+docker push ghcr.io/opendp/dpcreator/texlive-base:latest 
+
+```
+
+### Build the dpcreator/latex_service
+
+```
+docker build -t ghcr.io/opendp/dpcreator/latex-service:latest .
+docker push ghcr.io/opendp/dpcreator/latex-service:latest 
+```


### PR DESCRIPTION
Separate Dockerfile for the Python 3.9 + Tex Live to use as a base for the LaTeX service image.