### PR TITLE
Allow Dataverse site_url to not have "http://" prepended

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ server/scripts_dev/dv_test_creds.py
 !server/test_data/pdfs/*.pdf
 !dev_notes/api_example_analysis_plan.json
 .env
+!deploy/dataverse/*.json

--- a/client/src/views/Wizard.vue
+++ b/client/src/views/Wizard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="wizard-page">
-    <v-container v-if="!loading">
+    <v-container v-if="!loading && datasetInfo">
       <v-row>
         <v-col>
           <v-stepper v-model="stepperPosition" id="wizard-content" alt-labels>
@@ -107,6 +107,9 @@ export default {
       console.log('INIT stepper position')
       if (this.datasetInfo && this.getDepositorSetupInfo) {
         this.stepperPosition = stepInformation[this.userStep].wizardStepper
+        for (let index = 0; index < this.stepperPosition; index++) {
+          this.steps[index].completed = true
+        }
       }
     },
     gotoStep(step) {

--- a/client/src/views/WizardSteps/ConfirmVariables.vue
+++ b/client/src/views/WizardSteps/ConfirmVariables.vue
@@ -502,8 +502,13 @@ export default {
         }
         row.additional_information = {}
         if (this.isNumerical(row.type)) {
-          row.additional_information.max = vars[key].max
-          row.additional_information.min = vars[key].min
+          // Min and max are stored as ints, but the form expects them to be strings
+          if (vars[key].max !== undefined && vars[key].max !== null) {
+            row.additional_information.max = vars[key].max.toString()
+          }
+          if (vars[key].min !== undefined && vars[key].min !== null) {
+            row.additional_information.min = vars[key].min.toString()
+          }
         }
         if (row.type === 'Categorical') {
           // make a deep copy of the categories, so we can edit locally

--- a/client/src/views/WizardSteps/ValidateDataset.vue
+++ b/client/src/views/WizardSteps/ValidateDataset.vue
@@ -292,6 +292,9 @@ export default {
       const payload = {objectId: this.getDepositorSetupInfo.objectId, props: userInput}
       this.$store.dispatch('dataset/updateDepositorSetupInfo',
           payload)
+      if (this.radioOnlyOneIndividualPerRow == 'yes') {
+        this.$emit("stepCompleted", 0, true);
+      }
 
     },
     /* Epsilon & Delta are derived from the answers to the level of harm question,
@@ -345,12 +348,6 @@ export default {
       this.radioOnlyOneIndividualPerRow = "";
     }
   },
-  watch: {
-    radioOnlyOneIndividualPerRow: function (newValue) {
-      if (newValue !== "" && newValue !== "no") {
-        this.$emit("stepCompleted", 0, true);
-      }
-    }
-  }
+
 };
 </script>

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -70,9 +70,9 @@ Deployment currently requires the building of two Docker images:
     docker push ghcr.io/opendp/dpcreator/app:latest
    
     # Example:
-    docker build -t ghcr.io/opendp/dpcreator/app:2022-0118 .
-    docker push ghcr.io/opendp/dpcreator/app:2022-0118  
-    docker tag ghcr.io/opendp/dpcreator/app:2022-0118 ghcr.io/opendp/dpcreator/app:latest
+    docker build -t ghcr.io/opendp/dpcreator/app:2022-0119 .
+    docker push ghcr.io/opendp/dpcreator/app:2022-0119  
+    docker tag ghcr.io/opendp/dpcreator/app:2022-0119 ghcr.io/opendp/dpcreator/app:latest
     docker push ghcr.io/opendp/dpcreator/app:latest    
    ```
    
@@ -94,9 +94,9 @@ Deployment currently requires the building of two Docker images:
     docker push ghcr.io/opendp/dpcreator/nginx:latest
   
     # Example:
-    docker build -t ghcr.io/opendp/dpcreator/nginx:2022-0118 .
-    docker push ghcr.io/opendp/dpcreator/nginx:2022-0118
-    docker tag ghcr.io/opendp/dpcreator/nginx:2022-0118 ghcr.io/opendp/dpcreator/nginx:latest
+    docker build -t ghcr.io/opendp/dpcreator/nginx:2022-0119 .
+    docker push ghcr.io/opendp/dpcreator/nginx:2022-0119
+    docker tag ghcr.io/opendp/dpcreator/nginx:2022-0119 ghcr.io/opendp/dpcreator/nginx:latest
     docker push ghcr.io/opendp/dpcreator/nginx:latest  
     ```
 

--- a/deploy/dataverse/MANIFEST.md
+++ b/deploy/dataverse/MANIFEST.md
@@ -1,0 +1,30 @@
+## External Tools Manifest File
+
+
+```json
+{
+  "displayName": "DP Creator",
+  "description": "Create Differentially Private Statistics.",
+  "type": "explore",
+  "toolUrl": "http://dev.dpcreator.org/api/dv-handoff",
+  "toolParameters": {
+    "queryParameters": [
+      {
+        "fileId": "{fileId}"
+      },
+      {
+        "filePid": "{filePid}"
+      },
+      {
+        "datasetPid": "{datasetPid}"
+      },
+      {
+        "apiGeneralToken": "{apiToken}"
+      },
+	  {
+	   "site_url": "{siteUrl}"
+	  }
+    ]
+  }
+}
+```

--- a/deploy/dataverse/manifest_2021_1115b.json
+++ b/deploy/dataverse/manifest_2021_1115b.json
@@ -1,0 +1,31 @@
+{
+   "displayName":"Open Differential Privacy Application",
+   "description":"Create differentially private (DP) statistics on a sensitive data file using the OpenDP library created as part of the OpenDP Project. https://opendp.org",
+   "toolName":"DP Creator",
+   "scope":"file",
+   "type":"configure",
+   "toolUrl":"http://dev.dpcreator.org/api/dv-handoff/dv_orig_create/",
+   "contentType":"text/tab-separated-values",
+   "toolParameters":{
+      "queryParameters":[
+         {
+            "fileId":"{fileId}"
+         },
+         {
+            "apiGeneralToken":"{apiToken}"
+         },
+         {
+            "site_url":"{siteUrl}"
+         },
+         {
+            "filePid":"{filePid}"
+         },
+         {
+            "datasetPid":"{datasetPid}"
+         },
+         {
+            "datasetVersion":"{datasetVersion}"
+         }
+      ]
+   }
+}

--- a/server/opendp_apps/dataverses/fixtures/test_dataverses_01.json
+++ b/server/opendp_apps/dataverses/fixtures/test_dataverses_01.json
@@ -51,5 +51,18 @@
         "active": true,
         "notes": "Test Dataverse. Created on 7/12/2021"
     }
+},
+{
+    "model": "dataverses.registereddataverse",
+    "pk": 4,
+    "fields": {
+        "created": "2022-01-19T17:43:38.158Z",
+        "updated": "2022-01-19T17:45:52.624Z",
+        "object_id": "5bb1c891-3d85-4d27-8efa-7f14f7cd4779",
+        "name": "dev-dataverse.dpcreator.org",
+        "dataverse_url": "http://dev-dataverse.dpcreator.org",
+        "active": true,
+        "notes": ""
+    }
 }
 ]

--- a/server/opendp_apps/dataverses/models.py
+++ b/server/opendp_apps/dataverses/models.py
@@ -80,8 +80,7 @@ class RegisteredDataverse(TimestampedModelWithUUID):
         if dv_url.startswith('http://') or dv_url.startswith('https://'):
             return dv_url
 
-        if not dv_url.startswith('http://'):
-            dv_url = f'http://{dv_url}'
+        dv_url = f'http://{dv_url}'
 
         return dv_url
 

--- a/server/opendp_apps/dataverses/models.py
+++ b/server/opendp_apps/dataverses/models.py
@@ -67,11 +67,31 @@ class RegisteredDataverse(TimestampedModelWithUUID):
         return False
 
     @staticmethod
+    def hack_format_dv_url_http(dv_url):
+        """Hack for DV external tools change; If the url does not start with http(s), add 'http://'"""
+        if not isinstance(dv_url, str):
+            return None
+
+        dv_url = dv_url.lower().strip()
+
+        if not dv_url:
+            return None
+
+        if dv_url.startswith('http://') or dv_url.startswith('https://'):
+            return dv_url
+
+        if not dv_url.startswith('http://'):
+            dv_url = f'http://{dv_url}'
+
+        return dv_url
+
+    @staticmethod
     def format_dv_url(dv_url):
         """Trim trailing "/" and make lowercase. If it's an empty string or None, return None"""
         if not isinstance(dv_url, str):
             return None
 
+        dv_url = dv_url.strip()
         while dv_url and dv_url.endswith('/'):
             dv_url = dv_url[:-1]
 

--- a/server/opendp_apps/dataverses/testing/test_dataverse_handoff_view.py
+++ b/server/opendp_apps/dataverses/testing/test_dataverse_handoff_view.py
@@ -79,8 +79,12 @@ class TestDataverseHandoffView(TestCase):
         #
         url = reverse('dv-handoff-list')
 
+        #self.data[dv_static.DV_PARAM_SITE_URL] = 'dataverse.harvard.edu'
+
         response = self.client.post(url, data=self.data, format='json')
-        msg(response)
+
+        #msg(response)
+
         # Ensure redirect
         self.assertEqual(response.status_code, 302)
         # Ensure there is only one param in the redirect URL, and that it is an id

--- a/server/opendp_apps/dataverses/views/dataverse_handoff_view.py
+++ b/server/opendp_apps/dataverses/views/dataverse_handoff_view.py
@@ -62,6 +62,7 @@ class DataverseHandoffView(BaseModelViewSet):
 
         if dv_static.DV_PARAM_SITE_URL in request_data:
             init_site_url = request_data[dv_static.DV_PARAM_SITE_URL]
+            init_site_url = RegisteredDataverse.hack_format_dv_url_http(init_site_url)
             request_data[dv_static.DV_PARAM_SITE_URL] = RegisteredDataverse.format_dv_url(init_site_url)
 
         handoff_serializer = DataverseHandoffSerializer(data=request_data)

--- a/server/requirements/base.txt
+++ b/server/requirements/base.txt
@@ -37,7 +37,7 @@ uuid==1.30
 webencodings==0.5.1
 
 # async tasks
-celery==5.0.5
+celery==5.2.2
 
 
 # Django channels for websockets


### PR DESCRIPTION
This is a workaround to allow testing.

Previously, when sending the site_url parameter via a GET string, e.g. per the [docs](https://guides.dataverse.org/en/latest/api/external-tools.html#id9):
- `https://fabulousfiletool.com/?fileId=42&siteUrl=http://demo.dataverse.org`

However, in the latest iteration the http(s):// is not there, e.g. 

- `https://fabulousfiletool.com/?fileId=42&siteUrl=demo.dataverse.org`

This PR contains a hack to prepend `http://` if neither `http://` nor 'https://` starts the siteURL param.

(Note: This is a hack and messages are into Dataverse)