### PR TITLE
587 accuracy

### DIFF
--- a/client/cypress/fixtures/EyeDemoStatsTest.json
+++ b/client/cypress/fixtures/EyeDemoStatsTest.json
@@ -1,0 +1,35 @@
+{
+  "datasetName": "Eye-typing experiment",
+  "statistics": [
+    {
+      "statistic": "Mean",
+      "variable": "Trial",
+      "roundedAccuracy": "0.491",
+      "accuracy": 0.4911036518596695,
+      "fixedValue": "5"
+    },
+    {
+      "statistic": "Histogram",
+      "variable": "Trial",
+      "roundedAccuracy": "16.2",
+      "accuracy": 16.18088267924274,
+      "fixedValue": "5"
+    },
+    {
+      "statistic": "Mean",
+      "variable": "Trial",
+      "roundedAccuracy": "0.491",
+      "accuracy": 0.49110365185966957,
+      "fixedValue": "6"
+    }
+  ],
+  "variables": {
+    "Trial": {
+      "name": "Trial",
+      "label": "",
+      "type": "Integer",
+      "min": "0",
+      "max": "10"
+    }
+  }
+}

--- a/client/cypress/integration/create-statistics-spec.js
+++ b/client/cypress/integration/create-statistics-spec.js
@@ -9,15 +9,10 @@
             })
             cy.clearData()
 
-        })/*
-        it('distributes epsilon correctly ',()=> {
-            cy.on('uncaught:exception', (e, runnable) => {
-                console.log('error', e)
-                console.log('runnable', runnable)
-                return false
-            })
+        })
+        it('Updated dpStatistics Correctly', () => {
             const mockDVfile = 'EyeDemoMockDV.json'
-            const demoDatafile = 'createStats.json'
+            const demoDatafile = 'EyeDemoStatsTest.json'
 
             cy.createMockDataset(mockDVfile)
             cy.fixture(demoDatafile).then((demoData) => {
@@ -31,27 +26,10 @@
                 // Continue to Set Epsilon Step
                 cy.epsilonStep()
                 // Add all the statistics in the Create Statistics Step
-                cy.createStatistics(demoData).then(()=>{
-
-
-                // sum of individual epsilons should be < total epsilon
-                const sessionObj = JSON.parse(sessionStorage.getItem('vuex'))
-                const dpStatistics = sessionObj.dataset.analysisPlan.dpStatistics
-                const totalEpsilon = sessionObj.dataset.datasetInfo.depositorSetupInfo.epsilon
-                let sumEpsilon = 0;
-                dpStatistics.forEach(stat => { sumEpsilon += stat.epsilon})
-                    console.log('sumEpsilon')
-                expect(sumEpsilon <= -1)
-                cy.pause()
-
-                })
-
-
-
+                cy.createStatistics(demoData)
             })
-
         })
-*/
+
         it('Displays correct precision', () => {
             const mockDVfile = 'EyeDemoMockDV.json'
             const demoDatafile = 'EyeDemoData.json'
@@ -71,7 +49,6 @@
                 cy.createStatistics(demoData)
             })
         })
-
         it('Goes back to the Confirm Variables Page', () => {
             const mockDVfile = 'EyeDemoMockDV.json'
             const demoDatafile = 'EyeDemoData.json'

--- a/client/src/components/Accounts/SocialLoginButton.vue
+++ b/client/src/components/Accounts/SocialLoginButton.vue
@@ -70,7 +70,7 @@ export default {
     ...mapState('settings', ['vueSettings']),
     googleParams() {
       const googleParams = {
-        client_id: this.vueSettings['VUE_APP_GOOGLE_CLIENT_ID'],
+        client_id: this.vueSettings ? this.vueSettings['VUE_APP_GOOGLE_CLIENT_ID'] : 'vueSettings not initialized',
       }
       return googleParams
     }

--- a/client/src/views/WizardSteps/CreateStatistics.vue
+++ b/client/src/views/WizardSteps/CreateStatistics.vue
@@ -223,7 +223,7 @@ export default {
       this.$emit("addVariable")
     },
     save(editedItemFromDialog) {
-      this.editedItem = Object.assign({}, editedItemFromDialog);
+      this.editedItem = JSON.parse(JSON.stringify(editedItemFromDialog))
       if (this.isEditionMode) {
         Object.assign(this.statistics[this.editedIndex], this.editedItem);
       } else {
@@ -254,8 +254,6 @@ export default {
                 const accuracy = validateResults.data[i].accuracy
                 this.statistics[i].accuracy.value = Number(accuracy.value).toPrecision(3)
                 this.statistics[i].accuracy.message = accuracy.message
-                // this assigment below didn't work!  Can't change the object reference, need to change the values
-                //  this.statistics[i] = Object.assign({}, this.statistics[i], { accuracy })
               }
               this.saveUserInput()
             })

--- a/server/opendp_apps/analysis/templates/analysis/dp_histogram_accuracy_default.txt
+++ b/server/opendp_apps/analysis/templates/analysis/dp_histogram_accuracy_default.txt
@@ -1,3 +1,3 @@
-There is a probability of <b>{{ stat.get_cl_text }}</b> that a count in the  <b>DP {{ stat.statistic|title }}</b> will
-differ from the count in the true {{ stat.statistic|title }} by at most <b>{{ stat.accuracy_val }}</b>
-units. Here the units are the same units the variable <b>{{ stat.variable }}</b> has in the dataset.
+There is a probability of {{ stat.get_cl_text }} that a count in the  DP {{ stat.statistic|title }} will
+differ from the count in the true {{ stat.statistic|title }} by at most {{ stat.accuracy_val }}
+units. Here the units are the same units the variable {{ stat.variable }} has in the dataset.

--- a/server/opendp_apps/analysis/tools/dp_histogram_categorical_spec.py
+++ b/server/opendp_apps/analysis/tools/dp_histogram_categorical_spec.py
@@ -178,7 +178,7 @@ class DPHistogramCategoricalSpec(StatSpec):
         self.accuracy_val = laplacian_scale_to_accuracy(self.scale, cl_alpha)
 
         # Note `self.accuracy_val` must bet set before using `self.get_accuracy_text()
-        self.accuracy_msg = self.get_accuracy_text(template_name='analysis/dp_histogram_accuracy_default.html')
+        self.accuracy_msg = self.get_accuracy_text(template_name='analysis/dp_histogram_accuracy_default.txt')
 
         return True
 

--- a/server/opendp_apps/analysis/tools/dp_histogram_integer_spec.py
+++ b/server/opendp_apps/analysis/tools/dp_histogram_integer_spec.py
@@ -134,7 +134,7 @@ class DPHistogramIntegerSpec(StatSpec):
         self.accuracy_val = laplacian_scale_to_accuracy(self.scale, cl_alpha)
 
         # Note `self.accuracy_val` must bet set before using `self.get_accuracy_text()
-        self.accuracy_msg = self.get_accuracy_text(template_name='analysis/dp_histogram_accuracy_default.html')
+        self.accuracy_msg = self.get_accuracy_text(template_name='analysis/dp_histogram_accuracy_default.txt')
 
         return True
 

--- a/server/opendp_apps/analysis/validate_release_util.py
+++ b/server/opendp_apps/analysis/validate_release_util.py
@@ -371,6 +371,7 @@ class ValidateReleaseUtil(BasicErrCheck):
 
         # Iterate through the stat specs and validate them!
         #
+        self.validation_info = []  # reset validation info
         running_epsilon = 0.0
         for stat_spec in self.stat_spec_list:
             # Check each stat_spec


### PR DESCRIPTION
fixed the duplicate accuracy bug - the new stats objects weren't being added to the array with a deep copy, so they shared references to the same accuracy object.